### PR TITLE
Check TerminationDaemonBundle

### DIFF
--- a/src/main/scala/launcher.scala
+++ b/src/main/scala/launcher.scala
@@ -34,6 +34,7 @@ case object launcher extends LazyLogging {
               result.flatMap(_ => next.execute)
             }
 
+
         resourcesPrepared.flatMap { _ =>
           // if the resource are ready, launching manager locally
           resultToTry(
@@ -41,7 +42,7 @@ case object launcher extends LazyLogging {
           )
         }.map { _ =>
           // and finally if everything went fine so far, returning a ScheduledFuture with the termination monitor
-          TerminationDaemonBundle(
+          new TerminationDaemonBundleWithExplicitCreationTime(
             config,
             Scheduler(1),
             dataMappings.length
@@ -53,4 +54,26 @@ case object launcher extends LazyLogging {
       }
     }
   }
+}
+
+// The TerminationDaemonBundle in loquat defines its managerCreationTime value
+// querying the getCreatedTime method on the Option returned by
+// aws.as.getGroup(<group-name>). This works only when there is an actual
+// autoscaling group created. As webmiodx uses a local manager that is not
+// running in a external autoscaling group but in the web server itself (see
+// manager.localInstructions(user).run(localTmpDir) above), then the
+// aws.as.getGroup method returns None and the managerCreationTime value of
+// TerminationDaemonBundle in loquat is always None.
+// In order to terminate the instance when a global timeout is reached, we need
+// that the managerCreationTime value holds the actual creation time of the
+// manager. We do that here by overriding the value to an explicit instance of
+// Option[FiniteDuration], defined as the current time in millis.
+class TerminationDaemonBundleWithExplicitCreationTime(
+  override val config: AnyLoquatConfig,
+  override val scheduler: Scheduler,
+  override val initialCount: Int
+) extends TerminationDaemonBundle(config, scheduler, initialCount) {
+
+  override lazy val managerCreationTime = Some(System.currentTimeMillis.millis)
+
 }


### PR DESCRIPTION
The `TerminationDaemonBundle` (see https://github.com/era7bio/asdfjkl/blob/master/src/main/scala/launcher.scala#L44) does not terminate the group when the global timeout is reached. This is probably caused by the [`managerCreationTime` in Loquat](https://github.com/ohnosequences/loquat/blob/master/src/main/scala/ohnosequences/loquat/terminator.scala#L18) being `None` (HT @laughedelic :tada:).

We can either modify `TerminationDaemonBundle` or adapt the code from there in this project (the class is instantiated independently).